### PR TITLE
Change backend api to update movie in place

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -235,8 +235,7 @@ exports.updateMovie = function(req, res) {
 
     for(var i = 0; i < MOVIES.length; i++){
         if(MOVIES[i].id === id){
-            MOVIES.splice(i, 1);
-            MOVIES.push(movie);
+            MOVIES.splice(i, 1, movie);
             return res.json(200);
         }
     }


### PR DESCRIPTION
When updating a movie, the old movie object is removed from the array and the new one is pushed to the end which causes reordering of movies on the client side and general confusion in the audience.
